### PR TITLE
feat(ai): RecastNavMesh 디버그 시각화 컴포넌트 구현 [#19]

### DIFF
--- a/Game/Source/UE5TestProject/NavDebugVisualizerComponent.cpp
+++ b/Game/Source/UE5TestProject/NavDebugVisualizerComponent.cpp
@@ -1,0 +1,93 @@
+#include "NavDebugVisualizerComponent.h"
+#include "NavigationSystem.h"
+#include "NavigationData.h"
+#include "NavMesh/RecastNavMesh.h"
+#include "DrawDebugHelpers.h"
+#include "Engine/Engine.h"
+
+UNavDebugVisualizerComponent::UNavDebugVisualizerComponent()
+{
+	PrimaryComponentTick.bCanEverTick = true;
+}
+
+void UNavDebugVisualizerComponent::TickComponent(
+	float DeltaTime, ELevelTick TickType,
+	FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+	if (!bEnabled) return;
+
+	DrawNavPath();
+
+	if (PathStart)
+		DrawNavMeshInfo(PathStart->GetActorLocation());
+}
+
+void UNavDebugVisualizerComponent::DrawNavPath()
+{
+	if (!PathStart || !PathEnd) return;
+
+	UNavigationSystemV1* NavSys = UNavigationSystemV1::GetNavigationSystem(GetWorld());
+	if (!NavSys) return;
+
+	const ANavigationData* NavData = NavSys->GetDefaultNavDataInstance();
+	if (!NavData) return;
+
+	FPathFindingQuery Query(this, *NavData,
+		PathStart->GetActorLocation(),
+		PathEnd->GetActorLocation());
+
+	FPathFindingResult Result = NavSys->FindPathSync(Query);
+
+	if (!Result.IsSuccessful() || !Result.Path.IsValid())
+	{
+		DrawDebugLine(GetWorld(),
+			PathStart->GetActorLocation(),
+			PathEnd->GetActorLocation(),
+			FColor::Red, false, -1.f, 0, PathLineThickness);
+
+		if (GEngine)
+			GEngine->AddOnScreenDebugMessage(1, 0.f, FColor::Red, TEXT("PATH NOT FOUND"));
+		return;
+	}
+
+	const TArray<FNavPathPoint>& Points = Result.Path->GetPathPoints();
+	for (int32 i = 1; i < Points.Num(); ++i)
+	{
+		DrawDebugLine(GetWorld(),
+			Points[i - 1].Location + FVector(0, 0, 10),
+			Points[i].Location + FVector(0, 0, 10),
+			FColor::Green, false, -1.f, 0, PathLineThickness);
+	}
+
+	for (const FNavPathPoint& Pt : Points)
+		DrawDebugSphere(GetWorld(), Pt.Location, 15.f, 6, FColor::Yellow, false, -1.f);
+
+	if (GEngine)
+	{
+		GEngine->AddOnScreenDebugMessage(1, 0.f, FColor::Green,
+			FString::Printf(TEXT("PathPoints: %d  |  Length: %.0f cm"),
+				Points.Num(), Result.Path->GetLength()));
+	}
+}
+
+void UNavDebugVisualizerComponent::DrawNavMeshInfo(const FVector& Location)
+{
+	UNavigationSystemV1* NavSys = UNavigationSystemV1::GetNavigationSystem(GetWorld());
+	if (!NavSys) return;
+
+	FNavLocation NavLoc;
+	const bool bOnNav = NavSys->ProjectPointToNavigation(
+		Location, NavLoc, FVector(50.f, 50.f, 100.f));
+
+	DrawDebugSphere(GetWorld(), NavLoc.Location, 20.f, 8,
+		bOnNav ? FColor::Cyan : FColor::Red, false, -1.f);
+
+	if (GEngine)
+	{
+		GEngine->AddOnScreenDebugMessage(2, 0.f, FColor::Cyan,
+			FString::Printf(TEXT("OnNavMesh: %s  |  NodeRef: %llu"),
+				bOnNav ? TEXT("YES") : TEXT("NO"),
+				(uint64)NavLoc.NodeRef));
+	}
+}

--- a/Game/Source/UE5TestProject/NavDebugVisualizerComponent.h
+++ b/Game/Source/UE5TestProject/NavDebugVisualizerComponent.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "NavDebugVisualizerComponent.generated.h"
+
+/**
+ * RecastNavMesh 이해도 확인용 디버그 시각화 컴포넌트.
+ * 경로 쿼리 결과를 매 프레임 DrawDebug로 렌더링하고,
+ * NavMesh 위에서의 위치 투사 결과를 화면에 출력합니다.
+ *
+ * 활용:
+ *   - AGameMode나 임의 Actor에 부착
+ *   - PathStart, PathEnd 설정 후 PIE 실행
+ */
+UCLASS(ClassGroup=(Navigation), meta=(BlueprintSpawnableComponent))
+class UE5TESTPROJECT_API UNavDebugVisualizerComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+	UNavDebugVisualizerComponent();
+
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType,
+		FActorComponentTickFunction* ThisTickFunction) override;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="NavDebug")
+	AActor* PathStart = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="NavDebug")
+	AActor* PathEnd = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="NavDebug")
+	bool bEnabled = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="NavDebug")
+	float PathLineThickness = 5.f;
+
+private:
+	void DrawNavPath();
+	void DrawNavMeshInfo(const FVector& Location);
+};

--- a/Game/Source/UE5TestProject/UE5TestProject.Build.cs
+++ b/Game/Source/UE5TestProject/UE5TestProject.Build.cs
@@ -12,7 +12,8 @@ public class UE5TestProject : ModuleRules
 			"CoreUObject",
 			"Engine",
 			"InputCore",
-			"ModelViewViewModel"
+			"ModelViewViewModel",
+			"NavigationSystem"
 		});
 
 		PrivateDependencyModuleNames.AddRange(new string[]


### PR DESCRIPTION
## 요약

[#19](https://github.com/jiy12345/UE5TestProject/issues/19) 구현. [#10](https://github.com/jiy12345/UE5TestProject/issues/10)에서 분석한 RecastNavMesh 동작(경로 쿼리, NavMesh 투사, DynamicModifiersOnly 모드 등)을 런타임에 직접 확인하기 위한 디버그 시각화 컴포넌트.

## 변경 사항

- `Game/Source/UE5TestProject/NavDebugVisualizerComponent.h` - UActorComponent 헤더
- `Game/Source/UE5TestProject/NavDebugVisualizerComponent.cpp` - 매 프레임 DrawDebug 렌더링 구현
- `Game/Source/UE5TestProject/UE5TestProject.Build.cs` - `NavigationSystem` 모듈 의존성 추가

## 동작

| 항목 | 시각화 |
|---|---|
| 경로 (`FindPathSync` 성공) | 초록 선 + 노란 구체 (경유점) |
| 경로 (실패) | 빨간 선 + `PATH NOT FOUND` 메시지 |
| NavMesh 투사 (`ProjectPointToNavigation` 성공) | 시안 구체 + NodeRef 출력 |
| NavMesh 투사 (실패) | 빨간 구체 |
| 경로 정보 | 화면에 PathPoints 수, Length(cm) 출력 |

## 빌드 검증

- [x] UnrealHeaderTool: 새 헤더 파싱 성공 (3 files written)
- [x] UnrealBuildTool: `UnrealEditor-UE5TestProject.dll` 링크 성공 (Result: Succeeded)

## 동작 검증 (다음 PIE 세션에서)

이슈 #19의 체크리스트는 PIE 실행이 필요하므로 PR 머지 후 별도로 수행:

- [ ] GameMode/Actor에 컴포넌트 부착 후 PathStart/PathEnd 설정
- [ ] 경로 시각화 (초록 선/노란 구체) 표시 확인
- [ ] NavMesh 투사 (시안/빨강 구체) 표시 확인
- [ ] NavModifierVolume 배치 시 우회 경로 확인
- [ ] DynamicModifiersOnly 모드 런타임 추가/제거 시 경로 변화 확인
- [ ] 도달 불가 목표 시 PATH NOT FOUND 메시지 확인

## 관련

- Closes #19
- 분석 이슈: #10
- 관련 문서: `Docs/AI/RecastNavMesh/05-practical-guide.md` §4